### PR TITLE
[DCJ-15] Make DCJ team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Documentation with syntax examples:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+*       @DataBiosphere/data-custodian-journeys


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-15

### Summary

- Make @DataBiosphere/data-custodian-journeys (new Github team) the default codeowners.
  - I didn't know about this repository while updating the CODEOWNERS files of other DataBiosphere repos stewarded by the DCJ team.

@rushtong , I don't know if we also want to modify the settings of this repo to bring in DCJ team as an admin or writer (I myself don't have those privileges).